### PR TITLE
Build a custom csb image with a (near) empty brokerpak

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+zscaler.crt

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,27 @@
+# Use our hardened cloud-service-broker base image.
+ARG base_image
+
+# Builder: Build brokerpaks for use with cloud service broker.
+FROM ${base_image} AS build
+WORKDIR /app
+ADD ./brokerpaks ./brokerpaks
+
+ENV BUILD_ENV=development
+
+# For local builds only, add the ZScaler CA certificate to the trust store so Docker
+# can make HTTPS connections. `csb pak build` needs to do this to download binaries.
+# Find your ZScaler cert with $(brew --prefix)/etc/ca-certificates/cert.pem.
+# From https://help.zscaler.com/zia/adding-custom-certificate-application-specific-trust-store
+ADD zscaler.crt /tmp/zscaler.crt
+# Only copy Use BUILD_ENV variable within the container to copy the CA certificate into the certificate directory and update
+RUN if [ "$BUILD_ENV" = "production" ] ; then echo "production env"; else echo \
+"non-production env: $BUILD_ENV"; CERT_DIR=$(openssl version -d | cut -f2 -d \")/certs ; \
+cp /tmp/zscaler.crt $CERT_DIR ; update-ca-certificates ; \
+fi
+
+RUN /app/csb pak build brokerpaks/empty
+
+FROM ${base_image}
+
+# Copy brokerpaks to final image
+COPY --from=build /app/empty-1.0.0.brokerpak /app/

--- a/README.md
+++ b/README.md
@@ -1,3 +1,8 @@
-# Github templates
+# Cloud Service Broker
 
-This repo contains Github templates (pull request, issue, etc) for the cloud-gov organization.
+This repo contains configuration, including brokerpaks, for the cloud.gov deployment of the [Cloud Service Broker](https://github.com/cloudfoundry/cloud-service-broker).
+
+## Related projects
+
+- https://github.com/GSA-TTS/datagov-brokerpak-smtp
+- https://github.com/GSA/ttsnotify-brokerpak-sms

--- a/brokerpaks/empty/empty.yml
+++ b/brokerpaks/empty/empty.yml
@@ -1,0 +1,101 @@
+version: 1
+name: example-service
+id: ca14ec08-04db-47d5-bc87-1d1d3f688037
+description: a longer service description
+display_name: Example Service
+image_url: https://example.com/icon.jpg
+documentation_url: https://example.com
+provider_display_name: ""
+support_url: https://example.com/support.html
+tags: [gcp, example, service]
+plans:
+  - name: example-email-plan
+    id: 392417e9-8e96-4073-b238-a1b711db40f5
+    description: Builds emails for example.com.
+    display_name: example.com email builder
+    bullets:
+      - information point 1
+      - information point 2
+      - some caveat here
+    properties:
+      domain: example.com
+      password_special_chars: '@/ \"?'
+provision:
+  plan_inputs:
+    - required: true
+      field_name: domain
+      type: string
+      details: The domain name
+  user_inputs:
+    - required: true
+      field_name: username
+      type: string
+      details: The username to create
+  computed_inputs: []
+  template: |4-
+                    variable domain {type = string}
+                    variable username {type = string}
+                    output email {value = "${var.username}@${var.domain}"}
+
+  template_ref: ""
+  outputs:
+    - required: true
+      field_name: email
+      type: string
+      details: The combined email address
+  templates: {}
+  template_refs: {}
+  import_inputs: []
+  import_parameter_mappings: []
+  import_parameters_to_delete: []
+  import_parameters_to_add: []
+bind:
+  plan_inputs:
+    - required: true
+      field_name: password_special_chars
+      type: string
+      details: Supply your own list of special characters to use for string generation.
+  user_inputs: []
+  computed_inputs:
+    - name: domain
+      default: ${request.plan_properties["domain"]}
+      overwrite: true
+      type: ""
+    - name: address
+      default: ${instance.details["email"]}
+      overwrite: true
+      type: ""
+  template: |4-
+                    variable domain {type = string}
+                    variable address {type = string}
+                    variable password_special_chars {type = string}
+
+                    resource "random_string" "password" {
+                        length = 16
+                        special = true
+                        override_special = var.password_special_chars
+                    }
+
+                    output uri {value = "smtp://${var.address}:${random_string.password.result}@smtp.${var.domain}"}
+
+  template_ref: ""
+  outputs:
+    - required: true
+      field_name: uri
+      type: string
+      details: The uri to use to connect to this service
+  templates: {}
+  template_refs: {}
+  import_inputs: []
+  import_parameter_mappings: []
+  import_parameters_to_delete: []
+  import_parameters_to_add: []
+examples:
+  - name: Example
+    description: Examples are used for documenting your service AND as integration tests.
+    plan_id: 392417e9-8e96-4073-b238-a1b711db40f5
+    provision_params:
+      username: my-account
+    bind_params: {}
+plan_updateable: false
+requiredenvvars: []

--- a/brokerpaks/empty/manifest.yml
+++ b/brokerpaks/empty/manifest.yml
@@ -1,0 +1,15 @@
+packversion: 1
+name: empty
+version: "0.0.1"
+metadata:
+  author: James Hochadel
+platforms:
+- os: linux
+  arch: amd64
+terraform_binaries:
+- name: terraform
+  version: 1.7.5
+  source: https://github.com/hashicorp/terraform/archive/v1.7.5.zip
+service_definitions:
+- empty.yml
+parameters: []


### PR DESCRIPTION
## Changes proposed in this pull request:

Instead of figuring out how to pull the brokerpaks into the cloud-service-broker docker build environment, this repo will build on top of that image with our customizations.

Like all other images, this will be built by `common-pipelines`. For future iteration, I'll work from a topic branch in this repo.

Related to https://github.com/cloud-gov/product/issues/2943

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None.