### PR TITLE
Update the broker resource in CF upon every apply

### DIFF
--- a/ci/terraform/module/csb.tf
+++ b/ci/terraform/module/csb.tf
@@ -74,6 +74,9 @@ resource "cloudfoundry_service_broker" "csb" {
   username = "broker"
 
   depends_on = [cloudfoundry_app.csb]
+  labels = {
+    "last_updated" = timestamp() # We need the broker to update every time in case the catalog has changed. Terraform will only update the resource if it thinks it has changed. timestamp() will be different on every apply, causing an update.
+  }
 }
 
 # This data source is used in the for_each block of cloudfoundry_service_plan_visibility.csb to enable access to all plans the broker offers. Those plans are not available until the broker is created and registered. It would be best to establish a dependency on cloudfoundry_service_broker.csb so this data is only fetched after the broker is created and registered. However, terraform does not allow values that are known only after apply to be used in a for_each block. Adding the dependency causes the plan to fail with this error. As a result, we cannot establish a dependency in terraform. If you have created a new plan, you may need to run apply twice -- once to create the app and broker, during which this data block will populate without the new plan, and again, when it will populate with the new plan.


### PR DESCRIPTION
## Changes proposed in this pull request:

- See inline comment for full details.

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None.