### PR TITLE
Timestamp in its default format contains illegal characters

### DIFF
--- a/ci/terraform/module/csb.tf
+++ b/ci/terraform/module/csb.tf
@@ -75,7 +75,7 @@ resource "cloudfoundry_service_broker" "csb" {
 
   depends_on = [cloudfoundry_app.csb]
   labels = {
-    "last_updated" = timestamp() # We need the broker to update every time in case the catalog has changed. Terraform will only update the resource if it thinks it has changed. timestamp() will be different on every apply, causing an update.
+    "last_updated" = formatdate("YYYY-MM-DD'T'hhmmss", timestamp()) # We need the broker to update every time in case the catalog has changed. Terraform will only update the resource if it thinks it has changed. timestamp() will be different on every apply, causing an update.
   }
 }
 


### PR DESCRIPTION
## Changes proposed in this pull request:

- I believe the colons in the time are not allowed by CF.

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None.