### PR TITLE
Improve CSB deployment failure message

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -79,7 +79,7 @@ jobs:
             username: ((slack-username))
             icon_url: ((slack-icon-url))
             text: |
-              :x: FAILED to plan csb in development
+              :x: FAILED to plan csb in development. Please address this failure promptly so new image versions can be deployed or an outage will occur.
               <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
       - put: terraform-plugin-cache
         params:
@@ -122,7 +122,7 @@ jobs:
           params:
             <<: *slack-failure-config
             text: |
-              :x: FAILED to apply csb in development
+              :x: FAILED to apply csb in development. Please address this failure promptly so new image versions can be deployed or an outage will occur.
               <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
       - task: terraform-cleanup
         image: general-task
@@ -203,7 +203,7 @@ jobs:
           params:
             <<: *slack-failure-config
             text: |
-              :x: FAILED to plan csb in staging
+              :x: FAILED to plan csb in staging. Please address this failure promptly so new image versions can be deployed or an outage will occur.
               <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
 
   - name: terraform-apply-apps-staging
@@ -242,7 +242,7 @@ jobs:
           params:
             <<: *slack-failure-config
             text: |
-              :x: FAILED to apply csb in staging
+              :x: FAILED to apply csb in staging. Please address this failure promptly so new image versions can be deployed or an outage will occur.
               <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
       - task: terraform-cleanup
         image: general-task
@@ -323,7 +323,7 @@ jobs:
           params:
             <<: *slack-failure-config
             text: |
-              :x: FAILED to plan csb in production
+              :x: FAILED to plan csb in production. Please address this failure promptly so new image versions can be deployed or an outage will occur.
               <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
 
   - name: terraform-apply-apps-production
@@ -362,7 +362,7 @@ jobs:
           params:
             <<: *slack-failure-config
             text: |
-              :x: FAILED to apply csb in production
+              :x: FAILED to apply csb in production. Please address this failure promptly so new image versions can be deployed or an outage will occur.
               <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
       - task: terraform-cleanup
         image: general-task


### PR DESCRIPTION
## Changes proposed in this pull request:

We only keep 2 versions of docker images in each ECR registry, the two most recent. We delete older versions automatically. The CSB and Helper reference images by SHA, not floating tag. If this pipeline does not run, eventually the running app's SHA will reference a version that was removed from the registry. If the app restarts and tries to pull the image, it will fail, resulting in an outage.

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None