### PR TITLE
use separate variable to control access to CSB services in staging

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -186,7 +186,7 @@ jobs:
           TF_VAR_csb_docker_image_version: "@((.:csb-image-digest))"
           TF_VAR_csb_docproxy_domain: fr-stage.cloud.gov
           TF_VAR_csb_enable_service_access_global: false
-          TF_VAR_csb_enable_service_access_orgs: ((enable-service-access-orgs-production)) # temporary to test if it works as expected
+          TF_VAR_csb_enable_service_access_orgs: ((enable-service-access-orgs-staging))
           TF_VAR_csb_helper_docker_image_name: "((.:csb-helper-image-repository))"
           TF_VAR_csb_helper_docker_image_version: "@((.:csb-helper-image-digest))"
           TF_VAR_csb_org_name: ((csb-org-name))


### PR DESCRIPTION
## Changes proposed in this pull request:

- use separate variable to control access to CSB services in staging

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None
