### PR TITLE
re-add support for setting notification webhook on SES service bind

### DIFF
--- a/brokerpaks/aws-ses/aws-ses.yml
+++ b/brokerpaks/aws-ses/aws-ses.yml
@@ -149,6 +149,9 @@ bind:
     - field_name: notification_email
       type: string
       details: Email to subscribe to feedback notifications.
+    - field_name: notification_webhook
+      type: string
+      details: HTTPS endpoint to subscribe to feedback notifications.
   computed_inputs:
     - name: aws_access_key_id_govcloud
       type: string
@@ -229,6 +232,9 @@ bind:
     - field_name: notification_email
       type: string
       details: Subscribed email for feedback notifications
+    - field_name: notification_webhook
+      type: string
+      details: Subscribed endpoint for feedback notifications
   template_refs:
     main: terraform/bind/main.tf
     outputs: terraform/bind/outputs.tf

--- a/brokerpaks/aws-ses/terraform/bind/main.tf
+++ b/brokerpaks/aws-ses/terraform/bind/main.tf
@@ -1,10 +1,14 @@
 locals {
-  instance_sha                     = "ses-${substr(sha256(var.instance_id), 0, 16)}"
-  base_name                        = "csb-aws-ses-${var.binding_id}"
-  subscribe_bounce_notification    = (var.bounce_topic_arn != "" && var.notification_email != null)
-  subscribe_complaint_notification = (var.complaint_topic_arn != "" && var.notification_email != null)
-  subscribe_delivery_notification  = (var.delivery_topic_arn != "" && var.notification_email != null)
-  subscribed_email                 = ((local.subscribe_bounce_notification || local.subscribe_complaint_notification || local.subscribe_delivery_notification) ? var.notification_email : null)
+  instance_sha                             = "ses-${substr(sha256(var.instance_id), 0, 16)}"
+  base_name                                = "csb-aws-ses-${var.binding_id}"
+  subscribe_bounce_notification_email      = (var.bounce_topic_arn != "" && var.notification_email != null)
+  subscribe_complaint_notification_email   = (var.complaint_topic_arn != "" && var.notification_email != null)
+  subscribe_delivery_notification_email    = (var.delivery_topic_arn != "" && var.notification_email != null)
+  subscribed_email                         = ((local.subscribe_bounce_notification_email || local.subscribe_complaint_notification_email || local.subscribe_delivery_notification_email) ? var.notification_email : null)
+  subscribe_bounce_notification_webhook    = (var.bounce_topic_arn != "" && var.notification_webhook != null)
+  subscribe_complaint_notification_webhook = (var.complaint_topic_arn != "" && var.notification_webhook != null)
+  subscribe_delivery_notification_webhook  = (var.delivery_topic_arn != "" && var.notification_webhook != null)
+  subscribed_webhook                       = ((local.subscribe_bounce_notification_webhook || local.subscribe_complaint_notification_webhook || local.subscribe_delivery_notification_webhook) ? var.notification_webhook : null)
 }
 
 # Trivy: It is best practice to manage access via groups intead of by directly attaching
@@ -42,7 +46,7 @@ resource "aws_iam_user_policy" "user_policy" {
 }
 
 resource "aws_sns_topic_subscription" "bounce_subscription" {
-  count = (local.subscribe_bounce_notification ? 1 : 0)
+  count = (local.subscribe_bounce_notification_email ? 1 : 0)
 
   topic_arn = var.bounce_topic_arn
   protocol  = "email"
@@ -50,7 +54,7 @@ resource "aws_sns_topic_subscription" "bounce_subscription" {
 }
 
 resource "aws_sns_topic_subscription" "complaint_subscription" {
-  count = (local.subscribe_complaint_notification ? 1 : 0)
+  count = (local.subscribe_complaint_notification_email ? 1 : 0)
 
   topic_arn = var.complaint_topic_arn
   protocol  = "email"
@@ -58,9 +62,33 @@ resource "aws_sns_topic_subscription" "complaint_subscription" {
 }
 
 resource "aws_sns_topic_subscription" "delivery_subscription" {
-  count = (local.subscribe_delivery_notification ? 1 : 0)
+  count = (local.subscribe_delivery_notification_email ? 1 : 0)
 
   topic_arn = var.delivery_topic_arn
   protocol  = "email"
   endpoint  = var.notification_email
+}
+
+resource "aws_sns_topic_subscription" "bounce_subscription_https" {
+  count = (local.subscribe_bounce_notification_webhook ? 1 : 0)
+
+  topic_arn = var.bounce_topic_arn
+  protocol  = "https"
+  endpoint  = var.notification_webhook
+}
+
+resource "aws_sns_topic_subscription" "complaint_subscription_https" {
+  count = (local.subscribe_complaint_notification_webhook ? 1 : 0)
+
+  topic_arn = var.complaint_topic_arn
+  protocol  = "https"
+  endpoint  = var.notification_webhook
+}
+
+resource "aws_sns_topic_subscription" "delivery_subscription_https" {
+  count = (local.subscribe_delivery_notification_webhook ? 1 : 0)
+
+  topic_arn = var.delivery_topic_arn
+  protocol  = "https"
+  endpoint  = var.notification_webhook
 }

--- a/brokerpaks/aws-ses/terraform/bind/outputs.tf
+++ b/brokerpaks/aws-ses/terraform/bind/outputs.tf
@@ -23,3 +23,7 @@ output "aws_secret_access_key" {
 output "notification_email" {
   value = local.subscribed_email
 }
+
+output "notification_webhook" {
+  value = local.subscribed_webhook
+}

--- a/brokerpaks/aws-ses/terraform/bind/variables.tf
+++ b/brokerpaks/aws-ses/terraform/bind/variables.tf
@@ -57,8 +57,15 @@ variable "delivery_topic_arn" {
 }
 
 variable "notification_email" {
-  type    = string
-  default = ""
+  type        = string
+  default     = ""
+  description = "Email to subscribe to feedback notifications"
+}
+
+variable "notification_webhook" {
+  type        = string
+  default     = ""
+  description = "HTTPS endpoint to subscribe to feedback notifications"
 }
 
 variable "context" {


### PR DESCRIPTION
## Changes proposed in this pull request:

- re-add support for setting notification webhook on SES service bind

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None. Allowing customers to bind a webhook in addition to an email is another valid and secure way to receive SES feedback notifications (bounce, complaint, delivery).
